### PR TITLE
Ignorerer DoS vulnerabilities i micronaut i 2 måneder

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,9 +1,23 @@
 # Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
-version: v1.14.1
+version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
   SNYK-JAVA-COMFASTERXMLJACKSONCORE-2421244:
     - '*':
         reason: Open API is using bad version
         expires: 2025-07-08T06:14:39.494Z
+  SNYK-JAVA-ORGYAML-2806360:
+    - '*':
+        reason: >-
+          Currently no version of micronaut without vulnerability, DoS not
+          critical for this app
+        expires: 2022-11-01T00:00:00.000Z
+        created: 2022-08-31T12:44:45.037Z
+  SNYK-JAVA-ORGJSOUP-1567345:
+    - '*':
+        reason: >-
+          Currently no version of micronaut without vulnerability, DoS not
+          critical for this app
+        expires: 2022-11-01T00:00:00.000Z
+        created: 2022-08-31T12:45:55.924Z
 patch: {}


### PR DESCRIPTION
Ved bumping av micronaut og micronautOpenApi ble deploy stoppet av snyk med følgende melding:
```bash
Issues with no direct upgrade or patch:
  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGJSOUP-1567345] in org.jsoup:jsoup@1.11.3
    introduced by io.micronaut.openapi:micronaut-openapi@4.4.3 > com.vladsch.flexmark:flexmark-html2md-converter@0.62.2 > org.jsoup:jsoup@1.11.3
  This issue was fixed in versions: 1.14.2

  ✗ Denial of Service (DoS) [High Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGYAML-2806360] in org.yaml:snakeyaml@1.30
    introduced by io.micronaut:micronaut-runtime@3.6.1 > io.micronaut:micronaut-inject@3.6.1 > org.yaml:snakeyaml@1.30 and 1 other path(s)
  This issue was fixed in versions: 1.31
```

Det finnes per nå ingen nyere versjon av disse bibliotekene. 

Forslag til fiks er å ignorere i to måneder, og gjøre en revurdering da. Forhåpentligvis er micronaut oppgradert da.
Jeg tenker uvitende som jeg er at et DoS-angrep er høyst usannsynlig i api-dokumentasjonen. 