### PR TITLE
Legger til mulighet for å sette euresflagg ved import

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -563,6 +563,7 @@ Please specify as much data as possible on the property fields below.
 | jobpercentage | String | Optional | Stillingsprosent | if part time job, a percentage can be specified | eg 25% |
 | jobarrangement | String | Optional | Arbeidstidsordning | what type of jobarrangement | eg. Skift or Vakt |
 | remote | String | Optional | Hjemmekontor | Remote or hybrid workplace is possible | Hjemmekontor or Hybridkontor |
+| euresflagg | String | Optional | EURES-flagg | Marks a particular interest in recruiting workers from other European countries and provides additional visibility in the EURES job portal | true or false |
 
 
 ### Properties that support only valid values 

--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/properties/PropertyNameValueValidation.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/properties/PropertyNameValueValidation.kt
@@ -10,7 +10,7 @@ import jakarta.inject.Singleton
 class PropertyNameValueValidation {
 
     private val propertiesToValidate = listOf(extent, engagementtype, jobarrangement,
-            workday, workhours, sector, remote)
+            workday, workhours, sector, remote, euresflagg)
 
     val validValues = HashMap<PropertyNames,Set<String>>()
 
@@ -23,6 +23,7 @@ class PropertyNameValueValidation {
         // does not exist in AnsettelseKodeVerk
         validValues[sector] = hashSetOf("Privat", "Offentlig")
         validValues[remote] = hashSetOf("Hjemmekontor", "Hybridkontor")
+        validValues[euresflagg] = hashSetOf("true", "false")
     }
 
     fun validateProperty(name: PropertyNames, value: String) {

--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/properties/PropertyNames.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/properties/PropertyNames.kt
@@ -29,8 +29,8 @@ enum class PropertyNames(val type: PropertyType) {
     jobpercentage(PropertyType.TEXT),
     jobarrangement(PropertyType.TEXT),
     remote(PropertyType.TEXT),
-    arbeidsplassenoccupation(PropertyType.TEXT)
-
+    arbeidsplassenoccupation(PropertyType.TEXT),
+    euresflagg(PropertyType.TEXT),
 }
 
 enum class PropertyType {


### PR DESCRIPTION
Vi har heldigvis allerede alt vi trenger for å støtte euresflagg downstream.

Har fulgt flyten i dev fra `pam-import-api` ned til `pam-eures-stilling-eksport`, og det virker som om flagget blir satt riktig der.

`euresflagg` har fått typen `PropertyType.TEXT` istedet for `bool` fordi det er det som brukes videre i `pam-ad`, og div avro-skjemaer.