### PR TITLE
Setter podder max og min replica til 1

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -15,8 +15,8 @@ spec:
     path: /stillingsimport/internal/isReady
     initialDelay: 40
   replicas:
-    min: 2
-    max: 2
+    min: 1
+    max: 1
     cpuThresholdPercentage: 50
   resources:
     limits:


### PR DESCRIPTION
Skalerer ned til én pod for å klargjøre til prodsetting av import-api stillinger over kafka.
