### PR TITLE
Feature/bedre feilmelding

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
 # Enable auto-env through the sdkman_auto_env config
 # Add key=value pairs of SDKs to use below
-java=17.0.5-tem
+java=21.0.2-tem.

--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/exception/ImportApiErrorHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/exception/ImportApiErrorHandler.kt
@@ -80,7 +80,7 @@ private fun handleJsonProcessingException(error: JsonProcessingException): HttpR
     }
 }
 
-private fun feltFraPathReference(pathReference: String): String {
+fun feltFraPathReference(pathReference: String): String {
     val regex = """\["(.*?)"]""".toRegex() // Matcher grupper i hakeparantes
     val matches = regex.findAll(pathReference).map { it.groupValues[1] }.toList()
     return matches.lastOrNull() ?: pathReference

--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/transferlog/TransferController.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/transferlog/TransferController.kt
@@ -14,11 +14,13 @@ import io.micronaut.http.annotation.*
 import io.reactivex.Flowable
 import io.reactivex.schedulers.Schedulers
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
+import no.nav.arbeidsplassen.importapi.adstate.AdStateService
+import no.nav.arbeidsplassen.importapi.dto.AdDTO
+import no.nav.arbeidsplassen.importapi.dto.AdStatus
+import no.nav.arbeidsplassen.importapi.dto.TransferLogDTO
 import no.nav.arbeidsplassen.importapi.exception.ErrorType
 import no.nav.arbeidsplassen.importapi.exception.ImportApiError
-import no.nav.arbeidsplassen.importapi.adstate.AdStateService
-import no.nav.arbeidsplassen.importapi.dto.*
-import no.nav.arbeidsplassen.importapi.exception.ErrorMessage
+import no.nav.arbeidsplassen.importapi.exception.feltFraPathReference
 import no.nav.arbeidsplassen.importapi.provider.ProviderDTO
 import no.nav.arbeidsplassen.importapi.provider.ProviderService
 import no.nav.arbeidsplassen.importapi.security.ProviderAllowed
@@ -127,7 +129,7 @@ class TransferController(
             )
 
             is InvalidFormatException -> TransferLogDTO(
-                message = "Invalid value: ${error.value} at ${error.pathReference}",
+                message = "Invalid value: ${error.value} at ${feltFraPathReference(error.pathReference)}",
                 status = TransferLogStatus.ERROR,
                 providerId = provider.id!!
             )
@@ -139,7 +141,7 @@ class TransferController(
             )
 
             is MismatchedInputException -> TransferLogDTO(
-                    message = "Missing parameter: ${error.pathReference}",
+                    message = "Missing parameter: ${feltFraPathReference(error.pathReference)}",
                     status = TransferLogStatus.ERROR,
                     providerId = provider.id!!
             )


### PR DESCRIPTION
En veldig enkel hack for at feilmeldingene skal ende opp som 

```
{
  "message" : "Missing parameter: title",
  "errorType" : "MISSING_PARAMETER",
  "errorRef" : "895fdff5-6b37-446b-9654-51dc6d37b26b"
}
```

istedet for
```
{
    "message": "Missing parameter: java.util.ArrayList[0]->no.nav.arbeidsplassen.importapi.dto.AdDTO[\"title\"]",
    "errorType": "MISSING_PARAMETER",
    "errorRef": "683ee57f-88a3-41b7-a7a0-6bfddc55ab3d"
}
```