### PR TITLE
Legger til en test for AdPulsController 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,8 +18,8 @@ repositories {
     maven {
         url = uri("https://packages.confluent.io/maven/")
     }
-    maven { url ("https://jitpack.io") }
-    maven { url "https://github-package-registry-mirror.gc.nav.no/cached/maven-release"}
+    maven { url("https://jitpack.io") }
+    maven { url "https://github-package-registry-mirror.gc.nav.no/cached/maven-release" }
 }
 
 configurations {
@@ -55,7 +55,7 @@ dependencies {
     implementation "io.micronaut.micrometer:micronaut-micrometer-core"
     implementation "io.micronaut.micrometer:micronaut-micrometer-registry-prometheus"
     implementation "io.micronaut:micronaut-management"
-    implementation ("io.micronaut.kafka:micronaut-kafka:${micronautKafkaVersion}") {
+    implementation("io.micronaut.kafka:micronaut-kafka:${micronautKafkaVersion}") {
         exclude group: 'org.apache.kafka:kafka-clients'
     }
     implementation "org.apache.kafka:kafka-clients:3.6.1"
@@ -82,6 +82,7 @@ dependencies {
     testImplementation "org.junit.jupiter:junit-jupiter-engine:$jupiterEngineVersion"
     testImplementation("com.squareup.okhttp3:mockwebserver:$okhttpserverVersion")
     testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
+    testImplementation("net.javacrumbs.json-unit:json-unit:4.1.0")
 }
 
 test.classpath += configurations.developmentOnly

--- a/src/test/kotlin/no/nav/arbeidsplassen/importapi/adpuls/AdPulsControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/importapi/adpuls/AdPulsControllerTest.kt
@@ -1,0 +1,240 @@
+package no.nav.arbeidsplassen.importapi.adpuls
+
+import io.micronaut.context.annotation.Property
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpResponse
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.MediaType
+import io.micronaut.http.client.annotation.Client
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+import io.micronaut.rxjava3.http.client.Rx3HttpClient
+import io.micronaut.test.extensions.junit5.annotation.MicronautTest
+import jakarta.inject.Inject
+import java.time.LocalDateTime
+import java.util.UUID
+import net.javacrumbs.jsonunit.JsonAssert.assertJsonEquals
+import net.javacrumbs.jsonunit.JsonAssert.whenIgnoringPaths
+import no.nav.arbeidsplassen.importapi.dao.newTestProvider
+import no.nav.arbeidsplassen.importapi.provider.ProviderRepository
+import no.nav.arbeidsplassen.importapi.security.TokenService
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.fail
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import org.slf4j.LoggerFactory
+
+@MicronautTest
+@Property(name = "JWT_SECRET", value = "Thisisaverylongsecretandcanonlybeusedintest")
+class AdPulsControllerTest(
+    private val tokenService: TokenService,
+    private val repository: AdPulsRepository,
+    private val providerRepository: ProviderRepository
+) {
+    @Inject
+    @field:Client("\${micronaut.server.context-path}")
+    lateinit var client: Rx3HttpClient
+
+    companion object {
+        private val LOG = LoggerFactory.getLogger(AdPulsControllerTest::class.java)
+
+        @BeforeAll
+        @JvmStatic
+        fun createProvider(adPulsControllerTest: AdPulsControllerTest) {
+            val provider = adPulsControllerTest.providerRepository.newTestProvider()
+            val first = adPulsControllerTest.repository.save(
+                AdPuls(
+                    providerId = provider.id!!,
+                    uuid = UUID.randomUUID().toString(),
+                    reference = UUID.randomUUID().toString(),
+                    type = PulsEventType.pageviews,
+                    total = 10
+                )
+            )
+            val inDb = adPulsControllerTest.repository.findById(first.id!!).get()
+            val new = inDb.copy(total = 20)
+            adPulsControllerTest.repository.save(new)
+
+            adPulsControllerTest.repository.saveAll(
+                (1..20).map {
+                    Thread.sleep(1)
+                    AdPuls(
+                        providerId = provider.id!!,
+                        uuid = UUID.randomUUID().toString(),
+                        reference = UUID.randomUUID().toString(),
+                        type = PulsEventType.pageviews,
+                        total = it.toLong()
+                    )
+                }
+            )
+        }
+
+    }
+
+    @Test
+    fun `GET med sort, size og page skal fungere`() {
+        val providerId = 10000
+        val from = LocalDateTime.now().minusHours(20)
+        val adminToken = tokenService.adminToken()
+        val getRequest =
+            HttpRequest.GET<String>("/api/v1/stats/${providerId}?from=${from}&sort=created,asc&size=10&page=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .bearerAuth(adminToken)
+
+        val response: HttpResponse<String> = client.exchange(getRequest, String::class.java).blockingFirst()
+        assertEquals(HttpStatus.OK, response.status)
+
+        val expectedJson = """
+            {
+              "content" : [ ],
+              "pageable" : {
+                "number" : 1,
+                "sort" : {
+                  "orderBy" : [ {
+                    "property" : "created",
+                    "direction" : "ASC",
+                    "ignoreCase" : false,
+                    "ascending" : true
+                  } ]
+                },
+                "size" : 10
+              },
+              "numberOfElements" : 10,
+              "pageNumber" : 1,
+              "empty" : false,
+              "offset" : 10,
+              "size" : 10
+            }
+        """.trimIndent()
+        assertJsonEquals(
+            expectedJson,
+            response.body(),
+            whenIgnoringPaths("content")
+        )
+        LOG.info("Body" + response.body())
+    }
+
+    @Test
+    fun `GET uten sort, size og page skal gi defaults`() {
+        val providerId = 10000
+        val from = LocalDateTime.now().minusHours(20)
+        val adminToken = tokenService.adminToken()
+        val getRequest =
+            HttpRequest.GET<String>("/api/v1/stats/${providerId}?from=${from}")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .bearerAuth(adminToken)
+
+        val response: HttpResponse<String> = client.exchange(getRequest, String::class.java).blockingFirst()
+        assertEquals(HttpStatus.OK, response.status)
+
+        val expectedJson = """
+            {
+              "content" : [ ],
+              "pageable" : {
+                "number" : 0,
+                "sort" : {
+                  "orderBy" : [ {
+                    "property" : "updated",
+                    "direction" : "ASC",
+                    "ignoreCase" : false,
+                    "ascending" : true
+                  } ]
+                },
+                "size" : 1000
+              },
+              "numberOfElements" : 21,
+              "pageNumber" : 0,
+              "empty" : false,
+              "offset" : 0,
+              "size" : 1000
+            }
+        """.trimIndent()
+        assertJsonEquals(
+            expectedJson,
+            response.body(),
+            whenIgnoringPaths(
+                "content",
+                "pageable.sort.orderBy"
+            )
+            // Micronaut gir en tom orderBy når man ikke sender noe inn
+            // Her er spørringen som brukes:
+            // SELECT ad_puls_."id",ad_puls_."provider_id",ad_puls_."uuid",ad_puls_."reference",ad_puls_."type",ad_puls_."total",ad_puls_."created",ad_puls_."updated" FROM "ad_puls" ad_puls_ WHERE (ad_puls_."provider_id" = ? AND ad_puls_."updated" > ?) LIMIT 1000
+            // Dette er en dum spørring, så dette vil vi ikke videreføre når vi skriver vekk Micronaut Data. Derfor legger jeg til pageable.sort.orderBy på whenIgnoringPaths
+        )
+        LOG.info("Body" + response.body())
+    }
+
+    @Test
+    fun `GET med feilaktig sort skal gi 500`() {
+        val providerId = 10000
+        val from = LocalDateTime.now().minusHours(20)
+        val adminToken = tokenService.adminToken()
+        val getRequest =
+            HttpRequest.GET<String>("/api/v1/stats/${providerId}?from=${from}&sort=foobar,asc&size=10&page=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .bearerAuth(adminToken)
+
+        try {
+            client.exchange(getRequest, String::class.java).blockingFirst()
+            fail("Should have thrown HttpClientResponseException")
+            // Litt usikker på hvorfor den automatisk mapper til en exception i stedet for at dette fungerer:
+            // assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, response.status)
+        } catch (ex: HttpClientResponseException) {
+            assertEquals(HttpStatus.INTERNAL_SERVER_ERROR, ex.status)
+        }
+    }
+
+    @Test
+    fun `GET med sort men uten direction skal gi default direction`() {
+        val providerId = 10000
+        val from = LocalDateTime.now().minusHours(20)
+        val adminToken = tokenService.adminToken()
+        val getRequest =
+            HttpRequest.GET<String>("/api/v1/stats/${providerId}?from=${from}&sort=created&size=10&page=1")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON_TYPE)
+                .bearerAuth(adminToken)
+
+        val response: HttpResponse<String> = client.exchange(getRequest, String::class.java).blockingFirst()
+        assertEquals(HttpStatus.OK, response.status)
+
+        val expectedJson = """
+            {
+              "content" : [ ],
+              "pageable" : {
+                "number" : 1,
+                "sort" : {
+                  "orderBy" : [ {
+                    "property" : "updated",
+                    "direction" : "ASC",
+                    "ignoreCase" : false,
+                    "ascending" : true
+                  } ]
+                },
+                "size" : 10
+              },
+              "numberOfElements" : 10,
+              "pageNumber" : 1,
+              "empty" : false,
+              "offset" : 10,
+              "size" : 10
+            }
+        """.trimIndent()
+        assertJsonEquals(
+            expectedJson,
+            response.body(),
+            whenIgnoringPaths(
+                "content",
+                "pageable.sort.orderBy"
+            )
+            // Micronaut gir en tom orderBy når man ikke sender noe inn
+            // Her er spørringen som brukes:
+            // SELECT ad_puls_."id",ad_puls_."provider_id",ad_puls_."uuid",ad_puls_."reference",ad_puls_."type",ad_puls_."total",ad_puls_."created",ad_puls_."updated" FROM "ad_puls" ad_puls_ WHERE (ad_puls_."provider_id" = ? AND ad_puls_."updated" > ?) LIMIT 1000
+            // Dette er en dum spørring, så dette vil vi ikke videreføre når vi skriver vekk Micronaut Data. Derfor legger jeg til pageable.sort.orderBy på whenIgnoringPaths, vi vil legge til default sortering
+        )
+        LOG.info("Body" + response.body())
+    }
+
+}


### PR DESCRIPTION
AdPulsController lar dessverre Micronaut Data sine klasser Pageable og Slice blø helt ut gjennom REST-apiet. Når vi skal skrive vekk Micronaut Data må vi da lage noe som fungerer likt, så vi ikke knekker APIet. Denne testen legges til nå så vi kan verifisere senere at oppførselen til AdPulsController er lik når Micronaut Data er borte.