### PR TITLE
Jeg har lagt til en rekke tester av TransferLogController

### DIFF
--- a/src/test/kotlin/no/nav/arbeidsplassen/importapi/transferlog/TransferLogControllerTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/importapi/transferlog/TransferLogControllerTest.kt
@@ -19,6 +19,9 @@ import no.nav.arbeidsplassen.importapi.dto.TransferLogDTO
 import no.nav.arbeidsplassen.importapi.provider.ProviderDTO
 import no.nav.arbeidsplassen.importapi.security.TokenService
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 
 @MicronautTest
@@ -74,7 +77,7 @@ class TransferLogControllerTest(
     }
 
     @Test
-    fun `create provider then upload ads in stream`() {
+    fun `create provider then upload one ad in stream`() {
         val adminToken = tokenService.adminToken()
         val postProvider = HttpRequest.POST(
             "/internal/providers",
@@ -173,11 +176,180 @@ class TransferLogControllerTest(
     }
 
     @Test
-    fun `create provider then upload ads in stream with failure`() {
+    fun `create provider then upload two ads in stream`() {
+
         val adminToken = tokenService.adminToken()
         val postProvider = HttpRequest.POST(
             "/internal/providers",
-            ProviderDTO(identifier = "test3", email = "test3@test3.no", phone = "124")
+            ProviderDTO(identifier = "test3", email = "test3@test3.no", phone = "123")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+            {
+              "reference": "140095810",
+              "positions": 1,
+              "contactList": [
+                {
+                  "name": "Ola Norman",
+                  "title": "Regionleder",
+                  "email": "ola.normann@test.com",
+                  "phone": "+47 001 00 002"
+                },
+                {
+                  "name": "Kari Normann",
+                  "title": "Prosjektleder",
+                  "email": "kari.normann@test.com",
+                  "phone": "+47 003 00 004"
+                }
+              ],
+              "locationList": [
+                {
+                    "address": "Veien 2",
+                    "postalCode": "0001",
+                    "county": "Oslo",
+                    "municipal": "Oslo",
+                    "country": "Norge"
+                }
+              ],
+              "properties": {
+                "extent": "Heltid",
+                "employerhomepage": "http://www.sorumsand.norlandiabarnehagene.no",
+                "applicationdue": "24.02.2019",
+                "keywords": "Barnehage,daglig,leder,styrer",
+                "engagementtype": "Fast",
+                "employerdescription": "<p>I Norlandia barnehagene vil vi være med å skape livslang lyst til lek og læring. Hos oss er barnets beste alltid i sentrum. Våre medarbeidere er Norlandias viktigste innsatsfaktor, og lederskap vårt viktigste suksesskriterium. Våre ledere er sterke og selvstendige med ansvar for å utvikle lederteam i barnehagene, og for å bidra aktivt inn i Ledergruppen i Regionen. Norlandia Sørumsand vil være tilknyttet Region Øst.</p>\n",
+                "starttime": "01.05.2019",
+                "applicationemail": "ola.normann@test.com",
+                "applicationurl": "https://url.to.applicationform/recruitment/hire/input.action?adId=140095810",
+                "sector": "Offentlig",
+                "applicationlabel": "Søknad Sørumsand"
+              },
+              "title": "Ønsker du å lede en moderne og veletablert barnehage?",
+              "adText": "<p>Nå har du en unik mulighet til å lede en godt faglig og veletablert barnehage. Norlandia Sørumsand barnehage ble etablert i 2006 og har moderne og fleksible oppholdsarealer. Barnehagens satsningsområder er Mat med Smak og Null mobbing i barnehagen.</p>\n<p><strong>Hovedansvarsområder:</strong></p>\n<ul><li>Drifte og utvikle egen barnehage i tråd med gjeldende forskrifter, bestemmelser og Norlandias overordnete strategi</li><li>Personalansvar</li><li>Overordnet faglig ansvar i egen barnehage</li><li>Bidra og medvirke i regionens endrings -og strategiprosesser</li><li>Kvalitet i barnehagen i henhold til konsernets kvalitets- og miljøpolicy</li></ul>\n<p><strong>Ønskede kvalifikasjoner:</strong></p>\n<ul><li>Barnehagelærerutdanning</li><li>Gode lederegenskaper</li><li>Engasjement for mat og miljø</li><li>Økonomiforståelse</li><li>Beslutningsdyktig, proaktiv og løsningsorientert</li><li>Effektiv og evnen til å håndtere flere oppgaver samtidig</li><li>Være motivator og støttespiller for medarbeiderne</li><li>Ha gode strategiske evner</li></ul>\n<p><strong>Vi tilbyr:</strong></p>\n<ul><li>Jobb i et sterkt fagmiljø i stadig utvikling, med et stort handlingsrom innenfor fastsatte rammer</li><li>Korte beslutningsveier og muligheter for personlig og faglig utvikling</li><li>Gode personalfasiliteter</li><li>Konkurransedyktig lønn og gode pensjonsbetingelser</li><li>Gyldig politiattest (ikke eldre enn 3 måneder ved tiltredelse) må fremvises før ansettelse</li></ul>\n<p><em><strong>Dette er en unik mulighet til å få lede en moderne veletablert barnehage.</strong></em></p>\n",
+              "privacy": "SHOW_ALL",
+              "published": "2019-02-13T12:59:26",
+              "expires": "2019-02-24T00:00:00",
+              "employer": {
+                "id": 255533,
+                "reference": "232151232",
+                "businessName": "Sørumsand barnehage",
+                "orgnr": "989012088",
+                "location": {
+                  "address": "Sannergata 2",
+                  "postalCode": "0566",
+                  "country": "Norge",
+                  "county": "Oslo",
+                  "municipal": "Oslo",
+                  "city": "Oslo"
+                }
+              },
+              "categoryList": [
+                {
+                  "code": "234204",
+                  "categoryType": "STYRK08",
+                  "name": "Barnehagelærer"
+                }
+              ]
+            }
+            {
+              "reference": "140095811",
+              "positions": 1,
+              "contactList": [
+                {
+                  "name": "Ola Norman",
+                  "title": "Regionleder",
+                  "email": "ola.normann@test.com",
+                  "phone": "+47 001 00 002"
+                },
+                {
+                  "name": "Kari Normann",
+                  "title": "Prosjektleder",
+                  "email": "kari.normann@test.com",
+                  "phone": "+47 003 00 004"
+                }
+              ],
+              "locationList": [
+                {
+                    "address": "Veien 2",
+                    "postalCode": "0001",
+                    "county": "Oslo",
+                    "municipal": "Oslo",
+                    "country": "Norge"
+                }
+              ],
+              "properties": {
+                "extent": "Heltid",
+                "employerhomepage": "http://www.sorumsand.norlandiabarnehagene.no",
+                "applicationdue": "24.02.2019",
+                "keywords": "Barnehage,daglig,leder,styrer",
+                "engagementtype": "Fast",
+                "employerdescription": "<p>I Norlandia barnehagene vil vi være med å skape livslang lyst til lek og læring. Hos oss er barnets beste alltid i sentrum. Våre medarbeidere er Norlandias viktigste innsatsfaktor, og lederskap vårt viktigste suksesskriterium. Våre ledere er sterke og selvstendige med ansvar for å utvikle lederteam i barnehagene, og for å bidra aktivt inn i Ledergruppen i Regionen. Norlandia Sørumsand vil være tilknyttet Region Øst.</p>\n",
+                "starttime": "01.05.2019",
+                "applicationemail": "ola.normann@test.com",
+                "applicationurl": "https://url.to.applicationform/recruitment/hire/input.action?adId=140095810",
+                "sector": "Offentlig",
+                "applicationlabel": "Søknad Sørumsand"
+              },
+              "title": "Ønsker du å lede en moderne og veletablert barnehage?",
+              "adText": "<p>Nå har du en unik mulighet til å lede en godt faglig og veletablert barnehage. Norlandia Sørumsand barnehage ble etablert i 2006 og har moderne og fleksible oppholdsarealer. Barnehagens satsningsområder er Mat med Smak og Null mobbing i barnehagen.</p>\n<p><strong>Hovedansvarsområder:</strong></p>\n<ul><li>Drifte og utvikle egen barnehage i tråd med gjeldende forskrifter, bestemmelser og Norlandias overordnete strategi</li><li>Personalansvar</li><li>Overordnet faglig ansvar i egen barnehage</li><li>Bidra og medvirke i regionens endrings -og strategiprosesser</li><li>Kvalitet i barnehagen i henhold til konsernets kvalitets- og miljøpolicy</li></ul>\n<p><strong>Ønskede kvalifikasjoner:</strong></p>\n<ul><li>Barnehagelærerutdanning</li><li>Gode lederegenskaper</li><li>Engasjement for mat og miljø</li><li>Økonomiforståelse</li><li>Beslutningsdyktig, proaktiv og løsningsorientert</li><li>Effektiv og evnen til å håndtere flere oppgaver samtidig</li><li>Være motivator og støttespiller for medarbeiderne</li><li>Ha gode strategiske evner</li></ul>\n<p><strong>Vi tilbyr:</strong></p>\n<ul><li>Jobb i et sterkt fagmiljø i stadig utvikling, med et stort handlingsrom innenfor fastsatte rammer</li><li>Korte beslutningsveier og muligheter for personlig og faglig utvikling</li><li>Gode personalfasiliteter</li><li>Konkurransedyktig lønn og gode pensjonsbetingelser</li><li>Gyldig politiattest (ikke eldre enn 3 måneder ved tiltredelse) må fremvises før ansettelse</li></ul>\n<p><em><strong>Dette er en unik mulighet til å få lede en moderne veletablert barnehage.</strong></em></p>\n",
+              "privacy": "SHOW_ALL",
+              "published": "2019-02-13T12:59:26",
+              "expires": "2019-02-24T00:00:00",
+              "employer": {
+                "id": 255533,
+                "reference": "232151232",
+                "businessName": "Sørumsand barnehage",
+                "orgnr": "989012088",
+                "location": {
+                  "address": "Sannergata 2",
+                  "postalCode": "0566",
+                  "country": "Norge",
+                  "county": "Oslo",
+                  "municipal": "Oslo",
+                  "city": "Oslo"
+                }
+              },
+              "categoryList": [
+                {
+                  "code": "234204",
+                  "categoryType": "STYRK08",
+                  "name": "Barnehagelærer"
+                }
+              ]
+            }
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe { responseQueue.add(it) }
+        assertEquals(TransferLogStatus.RECEIVED, responseQueue.poll(5000, TimeUnit.MILLISECONDS)?.status)
+        assertEquals(TransferLogStatus.RECEIVED, responseQueue.poll(2000, TimeUnit.MILLISECONDS)?.status)
+
+//        Thread.sleep(60000) // takes too long
+//        val delete = HttpRequest.DELETE<TransferLogDTO>("/api/v1/transfers/${provider.id}/140095810?delete=true")
+//            .contentType(MediaType.APPLICATION_JSON)
+//            .accept(MediaType.APPLICATION_JSON_TYPE)
+//            .bearerAuth(providertoken)
+//        val deleteResp = client.exchange(delete,TransferLogDTO::class.java).blockingFirst().body()
+//        println(deleteResp)
+    }
+
+    @Test
+    fun `create provider then upload one and a half ads in stream with failure`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test4", email = "test4@test4.no", phone = "124")
         )
             .contentType(MediaType.APPLICATION_JSON)
             .accept(MediaType.APPLICATION_JSON_TYPE)
@@ -330,4 +502,302 @@ class TransferLogControllerTest(
         assertEquals(TransferLogStatus.ERROR, responseQueue.poll(2000, TimeUnit.MILLISECONDS)?.status)
     }
 
+    @Test
+    fun `create provider then upload zero ads in stream should fail`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test5", email = "test5@test5.no", phone = "124")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        var errorFromServer: Throwable? = null
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe({ responseQueue.add(it) }, { errorFromServer = it })
+        responseQueue.poll(2000, TimeUnit.MILLISECONDS)
+        assertNotNull(errorFromServer)
+        assertEquals("HttpClientResponseException", errorFromServer?.javaClass?.simpleName)
+        assertEquals("Client '/stillingsimport': Bad Request", errorFromServer?.message)
+    }
+
+    @Test
+    fun `create provider then upload gibberish before ad in stream should fail`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test6", email = "test6@test6.no", phone = "124")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+                jfkdfjdk
+            {
+              "reference": "140095810",
+              "positions": 1,
+              "contactList": [
+                {
+                  "name": "Ola Norman",
+                  "title": "Regionleder",
+                  "email": "ola.normann@test.com",
+                  "phone": "+47 001 00 002"
+                },
+                {
+                  "name": "Kari Normann",
+                  "title": "Prosjektleder",
+                  "email": "kari.normann@test.com",
+                  "phone": "+47 003 00 004"
+                }
+              ],
+              "locationList": [
+                {
+                    "address": "Veien 2",
+                    "postalCode": "0001",
+                    "county": "Oslo",
+                    "municipal": "Oslo",
+                    "country": "Norge"
+                }
+              ],
+              "properties": {
+                "extent": "Heltid",
+                "employerhomepage": "http://www.sorumsand.norlandiabarnehagene.no",
+                "applicationdue": "24.02.2019",
+                "keywords": "Barnehage,daglig,leder,styrer",
+                "engagementtype": "Fast",
+                "employerdescription": "<p>I Norlandia barnehagene vil vi være med å skape livslang lyst til lek og læring. Hos oss er barnets beste alltid i sentrum. Våre medarbeidere er Norlandias viktigste innsatsfaktor, og lederskap vårt viktigste suksesskriterium. Våre ledere er sterke og selvstendige med ansvar for å utvikle lederteam i barnehagene, og for å bidra aktivt inn i Ledergruppen i Regionen. Norlandia Sørumsand vil være tilknyttet Region Øst.</p>\n",
+                "starttime": "01.05.2019",
+                "applicationemail": "ola.normann@test.com",
+                "applicationurl": "https://url.to.applicationform/recruitment/hire/input.action?adId=140095810",
+                "sector": "Offentlig",
+                "applicationlabel": "Søknad Sørumsand"
+              },
+              "title": "Ønsker du å lede en moderne og veletablert barnehage?",
+              "adText": "<p>Nå har du en unik mulighet til å lede en godt faglig og veletablert barnehage. Norlandia Sørumsand barnehage ble etablert i 2006 og har moderne og fleksible oppholdsarealer. Barnehagens satsningsområder er Mat med Smak og Null mobbing i barnehagen.</p>\n<p><strong>Hovedansvarsområder:</strong></p>\n<ul><li>Drifte og utvikle egen barnehage i tråd med gjeldende forskrifter, bestemmelser og Norlandias overordnete strategi</li><li>Personalansvar</li><li>Overordnet faglig ansvar i egen barnehage</li><li>Bidra og medvirke i regionens endrings -og strategiprosesser</li><li>Kvalitet i barnehagen i henhold til konsernets kvalitets- og miljøpolicy</li></ul>\n<p><strong>Ønskede kvalifikasjoner:</strong></p>\n<ul><li>Barnehagelærerutdanning</li><li>Gode lederegenskaper</li><li>Engasjement for mat og miljø</li><li>Økonomiforståelse</li><li>Beslutningsdyktig, proaktiv og løsningsorientert</li><li>Effektiv og evnen til å håndtere flere oppgaver samtidig</li><li>Være motivator og støttespiller for medarbeiderne</li><li>Ha gode strategiske evner</li></ul>\n<p><strong>Vi tilbyr:</strong></p>\n<ul><li>Jobb i et sterkt fagmiljø i stadig utvikling, med et stort handlingsrom innenfor fastsatte rammer</li><li>Korte beslutningsveier og muligheter for personlig og faglig utvikling</li><li>Gode personalfasiliteter</li><li>Konkurransedyktig lønn og gode pensjonsbetingelser</li><li>Gyldig politiattest (ikke eldre enn 3 måneder ved tiltredelse) må fremvises før ansettelse</li></ul>\n<p><em><strong>Dette er en unik mulighet til å få lede en moderne veletablert barnehage.</strong></em></p>\n",
+              "privacy": "SHOW_ALL",
+              "published": "2019-02-13T12:59:26",
+              "expires": "2019-02-24T00:00:00",
+              "employer": {
+                "id": 255533,
+                "reference": "232151232",
+                "businessName": "Sørumsand barnehage",
+                "orgnr": "989012088",
+                "location": {
+                  "address": "Sannergata 2",
+                  "postalCode": "0566",
+                  "country": "Norge",
+                  "county": "Oslo",
+                  "municipal": "Oslo",
+                  "city": "Oslo"
+                }
+              },
+              "categoryList": [
+                {
+                  "code": "234204",
+                  "categoryType": "STYRK08",
+                  "name": "Barnehagelærer"
+                }
+              ]
+            }
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        var errorFromServer: Throwable? = null
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe({ responseQueue.add(it) }, { errorFromServer = it })
+        val transferLog = responseQueue.poll(2000, TimeUnit.MILLISECONDS)
+        assertNull(errorFromServer)
+        assertEquals(TransferLogStatus.ERROR, transferLog?.status)
+        assertTrue(transferLog!!.message!!.contains("JSON Parse error"))
+    }
+
+    @Test
+    fun `create provider then upload valid json that is not a adDTO in stream should fail`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test7", email = "test7@test7.no", phone = "124")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+            {
+              "foo": "bar"
+            }
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        var errorFromServer: Throwable? = null
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe({ responseQueue.add(it) }, { errorFromServer = it })
+        val transferLog = responseQueue.poll(2000, TimeUnit.MILLISECONDS)
+        assertNull(errorFromServer)
+        assertEquals(TransferLogStatus.ERROR, transferLog?.status)
+        assertTrue(transferLog!!.message!!.contains("Missing parameter: reference"))
+    }
+
+    @Test
+    fun `create provider then upload valid AdDTO json in array in stream should fail-ish`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test8", email = "test8@test8.no", phone = "124")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+            [
+            {
+              "reference": "140095810",
+              "positions": 1,
+              "contactList": [
+                {
+                  "name": "Ola Norman",
+                  "title": "Regionleder",
+                  "email": "ola.normann@test.com",
+                  "phone": "+47 001 00 002"
+                },
+                {
+                  "name": "Kari Normann",
+                  "title": "Prosjektleder",
+                  "email": "kari.normann@test.com",
+                  "phone": "+47 003 00 004"
+                }
+              ],
+              "locationList": [
+                {
+                    "address": "Veien 2",
+                    "postalCode": "0001",
+                    "county": "Oslo",
+                    "municipal": "Oslo",
+                    "country": "Norge"
+                }
+              ],
+              "properties": {
+                "extent": "Heltid",
+                "employerhomepage": "http://www.sorumsand.norlandiabarnehagene.no",
+                "applicationdue": "24.02.2019",
+                "keywords": "Barnehage,daglig,leder,styrer",
+                "engagementtype": "Fast",
+                "employerdescription": "<p>I Norlandia barnehagene vil vi være med å skape livslang lyst til lek og læring. Hos oss er barnets beste alltid i sentrum. Våre medarbeidere er Norlandias viktigste innsatsfaktor, og lederskap vårt viktigste suksesskriterium. Våre ledere er sterke og selvstendige med ansvar for å utvikle lederteam i barnehagene, og for å bidra aktivt inn i Ledergruppen i Regionen. Norlandia Sørumsand vil være tilknyttet Region Øst.</p>\n",
+                "starttime": "01.05.2019",
+                "applicationemail": "ola.normann@test.com",
+                "applicationurl": "https://url.to.applicationform/recruitment/hire/input.action?adId=140095810",
+                "sector": "Offentlig",
+                "applicationlabel": "Søknad Sørumsand"
+              },
+              "title": "Ønsker du å lede en moderne og veletablert barnehage?",
+              "adText": "<p>Nå har du en unik mulighet til å lede en godt faglig og veletablert barnehage. Norlandia Sørumsand barnehage ble etablert i 2006 og har moderne og fleksible oppholdsarealer. Barnehagens satsningsområder er Mat med Smak og Null mobbing i barnehagen.</p>\n<p><strong>Hovedansvarsområder:</strong></p>\n<ul><li>Drifte og utvikle egen barnehage i tråd med gjeldende forskrifter, bestemmelser og Norlandias overordnete strategi</li><li>Personalansvar</li><li>Overordnet faglig ansvar i egen barnehage</li><li>Bidra og medvirke i regionens endrings -og strategiprosesser</li><li>Kvalitet i barnehagen i henhold til konsernets kvalitets- og miljøpolicy</li></ul>\n<p><strong>Ønskede kvalifikasjoner:</strong></p>\n<ul><li>Barnehagelærerutdanning</li><li>Gode lederegenskaper</li><li>Engasjement for mat og miljø</li><li>Økonomiforståelse</li><li>Beslutningsdyktig, proaktiv og løsningsorientert</li><li>Effektiv og evnen til å håndtere flere oppgaver samtidig</li><li>Være motivator og støttespiller for medarbeiderne</li><li>Ha gode strategiske evner</li></ul>\n<p><strong>Vi tilbyr:</strong></p>\n<ul><li>Jobb i et sterkt fagmiljø i stadig utvikling, med et stort handlingsrom innenfor fastsatte rammer</li><li>Korte beslutningsveier og muligheter for personlig og faglig utvikling</li><li>Gode personalfasiliteter</li><li>Konkurransedyktig lønn og gode pensjonsbetingelser</li><li>Gyldig politiattest (ikke eldre enn 3 måneder ved tiltredelse) må fremvises før ansettelse</li></ul>\n<p><em><strong>Dette er en unik mulighet til å få lede en moderne veletablert barnehage.</strong></em></p>\n",
+              "privacy": "SHOW_ALL",
+              "published": "2019-02-13T12:59:26",
+              "expires": "2019-02-24T00:00:00",
+              "employer": {
+                "id": 255533,
+                "reference": "232151232",
+                "businessName": "Sørumsand barnehage",
+                "orgnr": "989012088",
+                "location": {
+                  "address": "Sannergata 2",
+                  "postalCode": "0566",
+                  "country": "Norge",
+                  "county": "Oslo",
+                  "municipal": "Oslo",
+                  "city": "Oslo"
+                }
+              },
+              "categoryList": [
+                {
+                  "code": "234204",
+                  "categoryType": "STYRK08",
+                  "name": "Barnehagelærer"
+                }
+              ]
+            }
+            ]
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        var errorFromServer: Throwable? = null
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe({ responseQueue.add(it) }, { errorFromServer = it })
+        val transferLog = responseQueue.poll(2000, TimeUnit.MILLISECONDS)
+        println(transferLog)
+        assertNull(errorFromServer)
+        // Server-koden her er veldig snål, man forventer plutselig å dekode json'en som en List<TransferLogDTO>,
+        // ikke som AdDTO som man ellers bruker, og man klarer det på sett og vis fordi man ignorerer de fleste feltene.
+        // Og man returnerer RECEIVED selv om man ikke har gjort et kvekk med det man mottok, det burde vært en ERROR
+        assertEquals(TransferLogStatus.RECEIVED, transferLog?.status)
+        assertNull(transferLog!!.message)
+        assertNull(transferLog.payload)
+        assertNull(transferLog.versionId)
+        assertEquals(0, transferLog.providerId)
+    }
+
+    @Test
+    fun `create provider then upload empty json array in stream should fail`() {
+        val adminToken = tokenService.adminToken()
+        val postProvider = HttpRequest.POST(
+            "/internal/providers",
+            ProviderDTO(identifier = "test9", email = "test8@test9.no", phone = "124")
+        )
+            .contentType(MediaType.APPLICATION_JSON)
+            .accept(MediaType.APPLICATION_JSON_TYPE)
+            .bearerAuth(adminToken)
+        val provider = client.exchange(postProvider, ProviderDTO::class.java).blockingFirst().body()
+        val providertoken = tokenService.token(provider!!)
+        // start the transfer
+        val post = HttpRequest.POST(
+            "/api/v1/transfers/${provider.id}", """
+            [
+            ]
+        """.trimIndent()
+        )
+            .contentType(MediaType.APPLICATION_JSON_STREAM)
+            .accept(MediaType.APPLICATION_JSON_STREAM_TYPE)
+            .bearerAuth(providertoken)
+        val response = strClient.jsonStream(post, TransferLogDTO::class.java)
+        var errorFromServer: Throwable? = null
+        val responseQueue = ArrayBlockingQueue<TransferLogDTO>(2)
+        response.subscribe({ responseQueue.add(it) }, { errorFromServer = it })
+        val transferLog = responseQueue.poll(2000, TimeUnit.MILLISECONDS)
+        assertNull(errorFromServer)
+        assertEquals(TransferLogStatus.ERROR, transferLog?.status)
+        // Dette er en bug i server-koden, den prøver å dekode inputen som en liste og så sende tilbake første innslag,
+        // men når listen er tom feiler det jo selvsagt..
+        assertTrue(transferLog!!.message!!.contains("Error: Index 0 out of bounds for length 0"))
+    }
 }


### PR DESCRIPTION
Jeg har lagt til en rekke tester av TransferLogController for å teste og dokumentere oppførsel ved ulike feilsituasjoner. Tanken er at jeg i så stor grad som mulig må gjenskape APIet vi tilbyr konsumentene våre når vi får fra Micronaut til Javalin, og da må jeg vite mer om hvordan vi håndterer ulike feilsituasjoner.

Samtidig blir jeg litt usikker, når jeg ser resultatet av testene. Det er en del situasjoner hvor jeg egentlig mener dagens kode burde gjort ting annerledes. Spørsmålet da blir om jeg skal videreføre det jeg mener er feil, eller om jeg skal gjøre det "bedre"? 

Disse f.eks synes jeg er interessante:
- er det noe poeng å feile hvis noen sender inn en tom body? (`create provider then upload zero ads in stream should fail`)
- når skal man feile med en exception og når skal man feile med en TransferLogDTO med feilmelding? (`create provider then upload zero ads in stream should fail` vs f.eks `create provider then upload gibberish before ad in stream should fail`)
- "Error: Index 0 out of bounds for length 0" er en meningsløs feilmelding å gi konsumenten.. (`create provider then upload empty json array in stream should fail`)
- er det ikke galt å returnere en RECEIVED når man ikke egentlig gjør noe, det er jo en feilsituasjon?! (`create provider then upload valid AdDTO json in array in stream should fail-ish`)
- burde man akseptere hvis streamen er "rammet inn" av en array eller ikke? (`create provider then upload valid AdDTO json in array in stream should fail-ish`)

Jeg tar gjerne en prat med noen om disse.. :) 