### PR TITLE
Endrer bruken av leaderelection i kafka pollingen

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/kafka/KafkaListenerStarter.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/kafka/KafkaListenerStarter.kt
@@ -43,7 +43,7 @@ class KafkaListenerStarter(
     }
 
     fun stop() {
-        if (adminStatusSyncKafkaEnabled && leaderElection.isLeader()) {
+        if (adminStatusSyncKafkaEnabled) {
             LOG.info("Stopper kafka rapid listener")
             try {
                 listenerThread.interrupt()


### PR DESCRIPTION
Endrer bruken av leaderelection i kafka pollingen, det ser ut til at sånn det var så ble det aldri noen lytting noe sted..

Jeg har flyttet isLeader sjekken fra while-conditionen og inn i selve løkka.