### PR TITLE
Nedjustere logging av en spesifikk exception

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/importapi/exception/ImportApiErrorHandler.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/importapi/exception/ImportApiErrorHandler.kt
@@ -8,17 +8,12 @@ import com.fasterxml.jackson.databind.exc.MismatchedInputException
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException
 import io.javalin.Javalin
 import io.javalin.http.HttpStatus
-import java.util.UUID
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.CONFLICT
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.INVALID_VALUE
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.MISSING_PARAMETER
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.NOT_FOUND
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.PARSE_ERROR
-import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.UNKNOWN
+import no.nav.arbeidsplassen.importapi.exception.ImportApiError.ErrorType.*
 import no.nav.arbeidsplassen.importapi.security.ForbiddenException
 import no.nav.arbeidsplassen.importapi.security.NotFoundException
 import no.nav.arbeidsplassen.importapi.security.UnauthorizedException
 import org.slf4j.LoggerFactory
+import java.util.*
 
 object ImportApiErrorHandler {
 
@@ -35,6 +30,9 @@ object ImportApiErrorHandler {
         return this
             .exception(ImportApiError::class.java) { e, ctx ->
                 val message: ErrorMessage = createMessage(e)
+                if (e.message?.startsWith("AdAdminStatus for") ?: false) {
+                    LOG.info("$message")
+                }
                 LOG.warn("$message", e)
                 val status: HttpStatus = when (e.type) {
                     NOT_FOUND -> HttpStatus.NOT_FOUND


### PR DESCRIPTION
Det kommer mange feil av typen AdAdminStatus for 10020, k73_t3005218 not found i prod, og de aller fleste av disse virker å være brukerfeil. Vi oppdaget riktignok en reell feil i prod i går pga dette, men den burde vi oppdaget pga Kafka consumer lag. Vi har nå sørget for at kafka lytteren er med i alert-opplegget, så neste gang får vi en alert hvis noe lignende skjer igjen som det som skjedde i går. Jeg tenker derfor det er trygt å justere ned feilmeldingene her fra warn til info og fjerne stacktracen, så blir det mindre støy i loggene i prod.