### PR TITLE
chore: update Nais resource limits

### DIFF
--- a/naiserator.yml
+++ b/naiserator.yml
@@ -20,11 +20,10 @@ spec:
     cpuThresholdPercentage: 50
   resources:
     limits:
-      cpu: 1000m
-      memory: 2048Mi
+      memory: 500Mi
     requests:
-      cpu: 200m
-      memory: 512Mi
+      cpu: 50m
+      memory: 320Mi
   vault:
     enabled: false
   webproxy: false


### PR DESCRIPTION
Right-sizes the pod resource configuration in `naiserator.yml` to better reflect actual usage.

**Changes:**
- Remove CPU limit (avoids CPU throttling on bursts)
- CPU request: `200m` -> `50m`
- Memory request: `512Mi` -> `320Mi`
- Memory limit: `2048Mi` -> `500Mi`