### PR TITLE
Use container-aware JVM memory percentages in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ COPY scripts/init-env.sh /init-scripts/init-env.sh
 COPY build/libs/pam-import-api-all.jar ./app.jar
 EXPOSE 9028
 
-ENV JAVA_OPTS="-Xms256m -Xmx1536m"
+ENV JAVA_TOOL_OPTIONS="-XX:InitialRAMPercentage=25 -XX:MaxRAMPercentage=70 -XX:+ExitOnOutOfMemoryError"
 ENV LANG='nb_NO.UTF-8' LANGUAGE='nb_NO:nb' LC_ALL='nb:NO.UTF-8' TZ="Europe/Oslo"
 
 ENTRYPOINT ["java","-jar","/app.jar"]


### PR DESCRIPTION
Hardcoded JVM heap values in the image did not reflect the reduced NAIS memory settings and could lead to mismatched runtime behavior.

This change replaces fixed `-Xms/-Xmx` values with container-aware JVM options in `JAVA_TOOL_OPTIONS`:
- `-XX:InitialRAMPercentage=25`
- `-XX:MaxRAMPercentage=70`
- `-XX:+ExitOnOutOfMemoryError`

This follows the same pattern used in `pam-annonsemottak`, so heap sizing now scales with the pod memory limits instead of relying on fixed MB values.