### PR TITLE
Bruk pam-deploy v9 i deploy-workflows

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -11,7 +11,7 @@ on:
       - feature/**
 jobs:
   call-workflow:
-    uses: navikt/pam-deploy/.github/workflows/deploy-dev.yml@v7
+    uses: navikt/pam-deploy/.github/workflows/deploy-dev.yml@v9
     permissions:
       actions: read
       contents: write

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   call-workflow:
-    uses: navikt/pam-deploy/.github/workflows/deploy-prod.yml@v7
+    uses: navikt/pam-deploy/.github/workflows/deploy-prod.yml@v9
     permissions:
       contents: write
       id-token: write


### PR DESCRIPTION
Oppdaterer deploy-workflows til `pam-deploy@v9` for å bruke siste felles deployoppsett.

Endrer `deploy-dev.yml` og `deploy-prod.yml` fra v7 til v9.